### PR TITLE
Receive message attributes support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in fake_sqs.gemspec
 gemspec
+
+gem 'aws-sdk', '~> 2.0.48'

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in fake_sqs.gemspec
 gemspec
-
-gem 'aws-sdk', '~> 2.0.48'

--- a/fake_sqs.gemspec
+++ b/fake_sqs.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "rspec"
   gem.add_development_dependency "rake"
-  gem.add_development_dependency "aws-sdk"
+  gem.add_development_dependency "aws-sdk", '~> 2.0.48'
   gem.add_development_dependency "faraday"
   gem.add_development_dependency "thin"
   gem.add_development_dependency "verbose_hash_fetch"

--- a/fake_sqs.gemspec
+++ b/fake_sqs.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "rspec"
   gem.add_development_dependency "rake"
-  gem.add_development_dependency "aws-sdk", '~> 2.0.48'
   gem.add_development_dependency "faraday"
   gem.add_development_dependency "thin"
   gem.add_development_dependency "verbose_hash_fetch"

--- a/fake_sqs.gemspec
+++ b/fake_sqs.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "sinatra"
   gem.add_dependency "builder"
-  gem.add_dependency 'aws-sdk', '~> 2.0'
+  gem.add_dependency 'aws-sdk'
 
   gem.add_development_dependency "rspec"
   gem.add_development_dependency "rake"

--- a/lib/fake_sqs/actions/receive_message.rb
+++ b/lib/fake_sqs/actions/receive_message.rb
@@ -18,9 +18,10 @@ module FakeSQS
               xml.ReceiptHandle receipt
               xml.MD5OfBody message.md5
               xml.Body message.body
-              message.attributes.each do |k, v|
+              message.attributes.each do |name, value|
                 xml.Attribute do
-                  xml.send(k, v)
+                  xml.Name name
+                  xml.Value value
                 end
               end
             end

--- a/lib/fake_sqs/actions/receive_message.rb
+++ b/lib/fake_sqs/actions/receive_message.rb
@@ -18,6 +18,11 @@ module FakeSQS
               xml.ReceiptHandle receipt
               xml.MD5OfBody message.md5
               xml.Body message.body
+              message.attributes.each do |k, v|
+                xml.Attribute do
+                  xml.send(k, v)
+                end
+              end
             end
           end
         end

--- a/lib/fake_sqs/message.rb
+++ b/lib/fake_sqs/message.rb
@@ -3,13 +3,14 @@ require 'securerandom'
 module FakeSQS
   class Message
 
-    attr_reader :body, :id, :md5
+    attr_reader :body, :id, :md5, :attributes
     attr_accessor :visibility_timeout
 
     def initialize(options = {})
       @body = options.fetch("MessageBody")
       @id = options.fetch("Id") { SecureRandom.uuid }
       @md5 = options.fetch("MD5") { Digest::MD5.hexdigest(@body) }
+      @attributes = default_attributes.merge(options["Attributes"] || {})
     end
 
     def expire!
@@ -24,11 +25,13 @@ module FakeSQS
       self.visibility_timeout = Time.now + seconds
     end
 
-    def attributes
+    private
+    def default_attributes
       {
-        "MessageBody" => body,
-        "Id" => id,
-        "MD5" => md5,
+        "SenderId" => SecureRandom.hex,
+        "SentTimestamp" => Time.now.to_i,
+        "ApproximateReceiveCount" => 0,
+        "ApproximateFirstReceiveTimestamp" => Time.now.to_i
       }
     end
 

--- a/spec/unit/message_spec.rb
+++ b/spec/unit/message_spec.rb
@@ -22,6 +22,22 @@ describe FakeSQS::Message do
     end
   end
 
+  describe "#attributes" do
+    it "is defaulted" do
+      message = create_message
+      expect(message.attributes["SenderId"]).not_to be_nil
+      expect(message.attributes["SentTimestamp"].to_i).to be >= Time.now.to_i
+      expect(message.attributes["ApproximateReceiveCount"]).to eq(0)
+      expect(message.attributes["ApproximateFirstReceiveTimestamp"]).to be >= Time.now.to_i
+    end
+
+    it "can be overriden" do
+      message = create_message("Attributes" => {"SenderId" => "foobar", "custom" => "values"})
+      expect(message.attributes["SenderId"]).to eq "foobar"
+      expect(message.attributes["custom"]).to eq("values")
+    end
+  end
+
   describe 'visibility_timeout' do
     let :message do
       create_message


### PR DESCRIPTION
@sandrasi this branch adds basic support for [Client#receive_message](http://docs.aws.amazon.com/sdkforruby/api/Aws/SQS/Client.html#receive_message-instance_method) Attributes support.  It allows overriding, but doesn't care about the `attribute_names` provided by the receive_message args.

If you want it to support the attribute_names, I will update the action to filter by the attribute_names provided, or no filter to "ALL" is provided, and none if not provided at all.

Here is the XML structure expected: http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html
